### PR TITLE
VM-32 Add full test coverage for updateVisitor (200/404/500)

### DIFF
--- a/backend/controllers/visitorController.js
+++ b/backend/controllers/visitorController.js
@@ -1,5 +1,5 @@
-const mongoose = require('mongoose');
 // backend/controllers/visitorController.js
+const mongoose = require('mongoose');
 const Visitor = require('../models/Visitor');
 
 /**
@@ -8,9 +8,10 @@ const Visitor = require('../models/Visitor');
  */
 const addVisitor = async (req, res) => {
   const { name, phone, purpose, host, checkIn, status } = req.body;
+
   try {
     const visitor = await Visitor.create({
-      userId: req.user.id,       // set by auth middleware
+      userId: req.user.id,             // set by auth middleware
       name,
       phone,
       purpose,
@@ -18,42 +19,46 @@ const addVisitor = async (req, res) => {
       checkIn: checkIn ? new Date(checkIn) : undefined,
       status,
     });
-    res.status(201).json(visitor);
+
+    return res.status(201).json(visitor);
   } catch (error) {
-    res.status(500).json({ message: error.message });
+    return res.status(500).json({ message: error.message });
   }
 };
 
 /**
  * GET /api/visitors
- * List all visitors for the logged-in user (new for VM‑5)
+ * List all visitors for the logged-in user
  */
 const getVisitors = async (req, res) => {
   try {
     const list = await Visitor
       .find({ userId: req.user.id })
       .sort({ createdAt: -1 }); // newest first
-    res.json(list);
+
+    return res.json(list);
   } catch (error) {
-    res.status(500).json({ message: error.message });
+    return res.status(500).json({ message: error.message });
   }
 };
 
 /**
  * PUT /api/visitors/:id
- * Update a visitor (only fields sent will be changed)
+ * Update a visitor (only fields provided will be changed)
  */
 const updateVisitor = async (req, res) => {
   const { id } = req.params;
 
-  // safety on bad ids
+  // Safety on bad IDs
   if (!mongoose.isValidObjectId(id)) {
     return res.status(400).json({ message: 'Invalid visitor id' });
   }
 
   try {
     const v = await Visitor.findById(id);
-    if (!v) return res.status(404).json({ message: 'Visitor not found' });
+    if (!v) {
+      return res.status(404).json({ message: 'Visitor not found' });
+    }
 
     const { name, phone, purpose, host, checkIn, checkOut, status } = req.body;
 
@@ -66,36 +71,37 @@ const updateVisitor = async (req, res) => {
     if (status !== undefined) v.status = status; // 'In' | 'Out'
 
     const updated = await v.save();
-    res.json(updated);
+    return res.status(200).json(updated);
   } catch (err) {
-    res.status(500).json({ message: err.message });
+    return res.status(500).json({ message: err.message });
   }
 };
 
-// DELETE /api/visitors/:id  (VM-7)
+/**
+ * DELETE /api/visitors/:id
+ * Delete a visitor (and ensure it belongs to this user, if you enforce that)
+ */
 const deleteVisitor = async (req, res) => {
   const { id } = req.params;
 
-  // Validate ObjectId so we don't crash on bad IDs
   if (!mongoose.isValidObjectId(id)) {
     return res.status(400).json({ message: 'Invalid visitor id' });
   }
 
   try {
-    // if you have auth, make sure the record belongs to this user
+    // If you want strict ownership, filter by both _id and userId
     const filter = req.user ? { _id: id, userId: req.user.id } : { _id: id };
-
     const deleted = await Visitor.findOneAndDelete(filter);
+
     if (!deleted) {
       return res.status(404).json({ message: 'Visitor not found' });
     }
 
-    res.json({ message: 'Visitor deleted', id: deleted._id });
+    return res.json({ message: 'Visitor deleted', id: deleted._id });
   } catch (err) {
-    res.status(500).json({ message: err.message });
+    return res.status(500).json({ message: err.message });
   }
 };
-
 
 module.exports = {
   addVisitor,

--- a/backend/test/visitors.update.test.js
+++ b/backend/test/visitors.update.test.js
@@ -1,0 +1,74 @@
+// backend/test/visitors.update.test.js
+const { expect } = require('chai');
+const sinon = require('sinon');
+const mongoose = require('mongoose');
+
+const { updateVisitor } = require('../controllers/visitorController');
+const Visitor = require('../models/Visitor');
+
+function makeRes() {
+  return { status: sinon.stub().returnsThis(), json: sinon.spy() };
+}
+
+describe('VM-6 updateVisitor', () => {
+  afterEach(() => sinon.restore());
+
+  it('updates a visitor and returns 200 with updated doc', async () => {
+    const id = new mongoose.Types.ObjectId();
+    const req = {
+      params: { id },
+      body: { name: 'Bob', phone: '0411111111' },
+      user: { id: 'user1' }
+    };
+    const res = makeRes();
+
+    // fake mongoose document with save()
+    const fakeDoc = {
+      _id: id,
+      name: 'Bob',
+      phone: '0411111111',
+      save: sinon.stub().resolvesThis()
+    };
+
+    sinon.stub(Visitor, 'findById').resolves(fakeDoc);
+
+    await updateVisitor(req, res);
+
+    expect(res.status.calledWith(200)).to.be.true;
+    expect(res.json.calledWithMatch({ _id: id })).to.be.true;
+  });
+
+  it('returns 404 when visitor not found', async () => {
+    const id = new mongoose.Types.ObjectId();
+    const req = {
+      params: { id },
+      body: { name: 'No One' },
+      user: { id: 'user1' }
+    };
+    const res = makeRes();
+
+    sinon.stub(Visitor, 'findById').resolves(null);
+
+    await updateVisitor(req, res);
+
+    expect(res.status.calledWith(404)).to.be.true;
+    expect(res.json.calledWithMatch({ message: sinon.match.string })).to.be.true;
+  });
+
+  it('handles errors and returns 500', async () => {
+    const id = new mongoose.Types.ObjectId();
+    const req = {
+      params: { id },
+      body: { name: 'Err' },
+      user: { id: 'user1' }
+    };
+    const res = makeRes();
+
+    sinon.stub(Visitor, 'findById').throws(new Error('DB Error'));
+
+    await updateVisitor(req, res);
+
+    expect(res.status.calledWith(500)).to.be.true;
+    expect(res.json.calledWithMatch({ message: 'DB Error' })).to.be.true;
+  });
+});


### PR DESCRIPTION
Added three Mocha/Chai/Sinon tests for updateVisitor
	•	Success path: returns 200 with updated doc (stubbed findById + save())
	•	Not found: returns 404 when findById resolves null
	•	Error path: returns 500 and error message when repository throws
	•	All VM‑4/5/6 tests now passing locally