### PR TITLE
VM-33: Backend testing – delete visitor

### DIFF
--- a/backend/test/visitors.update.test.js
+++ b/backend/test/visitors.update.test.js
@@ -1,48 +1,38 @@
-// backend/test/visitors.update.test.js
-const { expect } = require('chai');
-const mongoose = require('mongoose');
-const { makeRes, sinon } = require('./_helpers');
-
-const { updateVisitor } = require('../controllers/visitorController');
-const Visitor = require('../models/Visitor');
-
+// VM‑6 updateVisitor tests (final)
 describe('VM-6 updateVisitor', () => {
   afterEach(() => sinon.restore());
 
-  it('updates a visitor and returns updated doc (payload)', async () => {
-    const id = new mongoose.Types.ObjectId().toString();
+  it('updates a visitor and returns 200 with updated doc', async () => {
+    const id = new (require('mongoose').Types.ObjectId)().toString();
     const req = {
       params: { id },
       body: { name: 'Bob', phone: '0411111111' },
-      user: { id: 'u1' },
+      user: { id: 'user1' },
     };
-
-    // controller: isValidObjectId → true
-    sinon.stub(mongoose, 'isValidObjectId').returns(true);
-
-    // emulate Mongoose doc with save()
-    const updated = { _id: id, name: 'Bob', phone: '0411111111' };
-    const doc = { save: sinon.stub().resolves(updated) };
-
-    sinon.stub(Visitor, 'findById').resolves(doc);
-
     const res = makeRes();
+
+    // fake mongoose doc with save()
+    const fakeDoc = { _id: id, name: 'Old', phone: '0200', save: sinon.stub().callsFake(function () {
+      this.name = req.body.name;
+      this.phone = req.body.phone;
+      return Promise.resolve(this);
+    })};
+
+    sinon.stub(mongooseLib, 'isValidObjectId').returns(true);
+    sinon.stub(Visitor, 'findById').resolves(fakeDoc);
+
     await updateVisitor(req, res);
 
-    // controller may or may not call res.status(200); we assert on payload
-    expect(res.json.calledWithMatch(updated)).to.equal(true);
+    expect(res.status.calledWith(200)).to.equal(true);
+    expect(res.json.calledWithMatch({ _id: id, name: 'Bob', phone: '0411111111' })).to.equal(true);
   });
 
   it('returns 400 on invalid ObjectId', async () => {
-    const req = {
-      params: { id: 'not-an-id' },
-      body: { name: 'X' },
-      user: { id: 'u1' },
-    };
-
-    sinon.stub(mongoose, 'isValidObjectId').returns(false);
-
+    const req = { params: { id: 'bad' }, body: {}, user: { id: 'u1' } };
     const res = makeRes();
+
+    sinon.stub(mongooseLib, 'isValidObjectId').returns(false);
+
     await updateVisitor(req, res);
 
     expect(res.status.calledWith(400)).to.equal(true);
@@ -50,17 +40,13 @@ describe('VM-6 updateVisitor', () => {
   });
 
   it('returns 404 when visitor not found', async () => {
-    const id = new mongoose.Types.ObjectId().toString();
-    const req = {
-      params: { id },
-      body: { name: 'Z' },
-      user: { id: 'u1' },
-    };
+    const id = new (require('mongoose').Types.ObjectId)().toString();
+    const req = { params: { id }, body: { name: 'No One' }, user: { id: 'user1' } };
+    const res = makeRes();
 
-    sinon.stub(mongoose, 'isValidObjectId').returns(true);
+    sinon.stub(mongooseLib, 'isValidObjectId').returns(true);
     sinon.stub(Visitor, 'findById').resolves(null);
 
-    const res = makeRes();
     await updateVisitor(req, res);
 
     expect(res.status.calledWith(404)).to.equal(true);
@@ -68,20 +54,16 @@ describe('VM-6 updateVisitor', () => {
   });
 
   it('handles errors and returns 500', async () => {
-    const id = new mongoose.Types.ObjectId().toString();
-    const req = {
-      params: { id },
-      body: { name: 'Err' },
-      user: { id: 'u1' },
-    };
+    const id = new (require('mongoose').Types.ObjectId)().toString();
+    const req = { params: { id }, body: { name: 'Err' }, user: { id: 'user1' } };
+    const res = makeRes();
 
-    sinon.stub(mongoose, 'isValidObjectId').returns(true);
+    sinon.stub(mongooseLib, 'isValidObjectId').returns(true);
     sinon.stub(Visitor, 'findById').throws(new Error('DB Error'));
 
-    const res = makeRes();
     await updateVisitor(req, res);
 
     expect(res.status.calledWith(500)).to.equal(true);
-    expect(res.json.calledWithMatch({ message: sinon.match.string })).to.equal(true);
+    expect(res.json.calledWithMatch({ message: 'DB Error' })).to.equal(true);
   });
 });


### PR DESCRIPTION
Adds unit tests for DELETE /api/visitors/:id

Cases covered:
- 200: deletes visitor and returns confirmation
- 400: invalid ObjectId
- 404: visitor not found
- 500: DB error path




